### PR TITLE
Update python version CI.

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: 3.14
 
       - name: Install ruff
         run: |
@@ -28,7 +28,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.11, 3.12, 3.13]
+        python-version: [3.12, 3.13, 3.14]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Dev is now done on Django 6. Which supports Python 3.12, 3.13 and 3.14